### PR TITLE
Hardening storage API, HTTP configuration, and login flow

### DIFF
--- a/SistemaVeterinario.Api/Contracts/Requests/CreateFileResourceRequest.cs
+++ b/SistemaVeterinario.Api/Contracts/Requests/CreateFileResourceRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SistemaVeterinario.Api.Contracts.Requests;
+
+public sealed record CreateFileResourceRequest
+{
+    [MaxLength(64)]
+    public string? MascotaId { get; init; }
+}

--- a/SistemaVeterinario.Api/Contracts/Responses/FileResourceResponse.cs
+++ b/SistemaVeterinario.Api/Contracts/Responses/FileResourceResponse.cs
@@ -1,0 +1,3 @@
+namespace SistemaVeterinario.Api.Contracts.Responses;
+
+public sealed record FileResourceResponse(string ResourceId, string RelativePath);

--- a/SistemaVeterinario.Api/Controllers/FilesController.cs
+++ b/SistemaVeterinario.Api/Controllers/FilesController.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SistemaVeterinario.Api.Contracts.Requests;
+using SistemaVeterinario.Api.Contracts.Responses;
+using SistemaVeterinario.Api.Services;
+
+namespace SistemaVeterinario.Api.Controllers;
+
+[ApiController]
+[Route("api/archivos")]
+[Authorize]
+public sealed class FilesController : ControllerBase
+{
+    private readonly IFileStorageService storageService;
+    private readonly ILogger<FilesController> logger;
+
+    public FilesController(IFileStorageService storageService, ILogger<FilesController> logger)
+    {
+        this.storageService = storageService;
+        this.logger = logger;
+    }
+
+    [HttpPost("{clienteId}")]
+    [ProducesResponseType(typeof(FileResourceResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<FileResourceResponse>> CreateAsync(string clienteId, [FromBody] CreateFileResourceRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await storageService.EnsureResourceAsync(clienteId, request, cancellationToken);
+            return Created(string.Empty, response);
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogWarning(ex, "Error al crear recurso de archivos para el cliente {ClienteId}", clienteId);
+            return ValidationProblem(new ValidationProblemDetails
+            {
+                Title = "Solicitud inválida",
+                Detail = ex.Message,
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogError(ex, "Configuración inválida al crear recurso de archivos");
+            return Problem(ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+}

--- a/SistemaVeterinario.Api/Options/FileStorageOptions.cs
+++ b/SistemaVeterinario.Api/Options/FileStorageOptions.cs
@@ -1,0 +1,10 @@
+using System.IO;
+
+namespace SistemaVeterinario.Api.Options;
+
+public sealed class FileStorageOptions
+{
+    public const string SectionName = "FileStorage";
+
+    public string BasePath { get; set; } = Path.Combine(AppContext.BaseDirectory, "uploads");
+}

--- a/SistemaVeterinario.Api/Program.cs
+++ b/SistemaVeterinario.Api/Program.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using SistemaVeterinario.Api.Options;
+using SistemaVeterinario.Api.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<FileStorageOptions>(builder.Configuration.GetSection(FileStorageOptions.SectionName));
+builder.Services.AddSingleton<IFileStorageService, LocalFileStorageService>();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.Authority = builder.Configuration["Jwt:Authority"];
+        options.Audience = builder.Configuration["Jwt:Audience"];
+        options.RequireHttpsMetadata = true;
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = !string.IsNullOrWhiteSpace(options.Authority),
+            ValidateAudience = !string.IsNullOrWhiteSpace(options.Audience),
+            ValidateLifetime = true
+        };
+    });
+
+builder.Services.AddAuthorization();
+
+builder.Services.AddControllers();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/SistemaVeterinario.Api/Properties/launchSettings.json
+++ b/SistemaVeterinario.Api/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "SistemaVeterinario.Api": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7218;http://localhost:5218",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/SistemaVeterinario.Api/Services/IFileStorageService.cs
+++ b/SistemaVeterinario.Api/Services/IFileStorageService.cs
@@ -1,0 +1,9 @@
+using SistemaVeterinario.Api.Contracts.Requests;
+using SistemaVeterinario.Api.Contracts.Responses;
+
+namespace SistemaVeterinario.Api.Services;
+
+public interface IFileStorageService
+{
+    Task<FileResourceResponse> EnsureResourceAsync(string clienteId, CreateFileResourceRequest request, CancellationToken cancellationToken);
+}

--- a/SistemaVeterinario.Api/Services/LocalFileStorageService.cs
+++ b/SistemaVeterinario.Api/Services/LocalFileStorageService.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SistemaVeterinario.Api.Contracts.Requests;
+using SistemaVeterinario.Api.Contracts.Responses;
+using SistemaVeterinario.Api.Options;
+
+namespace SistemaVeterinario.Api.Services;
+
+public sealed class LocalFileStorageService : IFileStorageService
+{
+    private static readonly Regex UnsafeSegment = new("[^a-zA-Z0-9_-]", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private readonly FileStorageOptions options;
+    private readonly ILogger<LocalFileStorageService> logger;
+
+    public LocalFileStorageService(IOptions<FileStorageOptions> options, ILogger<LocalFileStorageService> logger)
+    {
+        this.options = options.Value;
+        this.logger = logger;
+    }
+
+    public Task<FileResourceResponse> EnsureResourceAsync(string clienteId, CreateFileResourceRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clienteId);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var sanitizedClienteId = Sanitize(clienteId);
+        if (string.IsNullOrEmpty(sanitizedClienteId))
+        {
+            throw new ArgumentException("El identificador del cliente es inválido", nameof(clienteId));
+        }
+
+        var baseDirectory = EnsureBaseDirectory();
+        var clienteDirectory = Path.Combine(baseDirectory, $"cliente_{sanitizedClienteId}");
+        Directory.CreateDirectory(clienteDirectory);
+
+        string relativePath;
+        if (!string.IsNullOrWhiteSpace(request.MascotaId))
+        {
+            var sanitizedMascotaId = Sanitize(request.MascotaId);
+            if (string.IsNullOrEmpty(sanitizedMascotaId))
+            {
+                throw new ArgumentException("El identificador de la mascota es inválido", nameof(request.MascotaId));
+            }
+
+            var mascotaDirectory = Path.Combine(clienteDirectory, $"mascota_{sanitizedMascotaId}");
+            Directory.CreateDirectory(mascotaDirectory);
+            relativePath = Path.GetRelativePath(baseDirectory, mascotaDirectory);
+        }
+        else
+        {
+            relativePath = Path.GetRelativePath(baseDirectory, clienteDirectory);
+        }
+
+        var response = new FileResourceResponse(Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture), relativePath.Replace('\', '/'));
+        logger.LogInformation("Se aseguró el recurso de archivos {RelativePath} para el cliente {ClienteId}", relativePath, sanitizedClienteId);
+        return Task.FromResult(response);
+    }
+
+    private string EnsureBaseDirectory()
+    {
+        var basePath = options.BasePath;
+        if (string.IsNullOrWhiteSpace(basePath))
+        {
+            throw new InvalidOperationException("La ruta base de almacenamiento no está configurada.");
+        }
+
+        Directory.CreateDirectory(basePath);
+        return basePath;
+    }
+
+    private static string Sanitize(string? segment)
+    {
+        if (string.IsNullOrWhiteSpace(segment))
+        {
+            return string.Empty;
+        }
+
+        return UnsafeSegment.Replace(segment, string.Empty);
+    }
+}

--- a/SistemaVeterinario.Api/SistemaVeterinario.Api.csproj
+++ b/SistemaVeterinario.Api/SistemaVeterinario.Api.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/SistemaVeterinario.Api/appsettings.Development.json
+++ b/SistemaVeterinario.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/SistemaVeterinario.Api/appsettings.json
+++ b/SistemaVeterinario.Api/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "FileStorage": {
+    "BasePath": "App_Data/uploads"
+  },
+  "Jwt": {
+    "Authority": "",
+    "Audience": ""
+  }
+}

--- a/SistemaVeterinario.Backend/Entities/Responses/ApiResponse.cs
+++ b/SistemaVeterinario.Backend/Entities/Responses/ApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace SistemaVeterinario.Backend.Entities.Responses;
+
+public class ApiResponse<T>
+{
+    [JsonPropertyName("statusCode")]
+    public int StatusCode { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+
+    [JsonPropertyName("items")]
+    public T? Items { get; set; }
+
+    [JsonIgnore]
+    public bool IsSuccess => StatusCode is >= 200 and < 300;
+}

--- a/SistemaVeterinario.Backend/Entities/Responses/LoginEnvelopeItem.cs
+++ b/SistemaVeterinario.Backend/Entities/Responses/LoginEnvelopeItem.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+using SistemaVeterinario.Backend.Entities.Dtos;
+using SistemaVeterinario.Backend.Entities.Models;
+
+namespace SistemaVeterinario.Backend.Entities.Responses;
+
+public class LoginEnvelopeItem
+{
+    [JsonPropertyName("login")]
+    public AdmUser? Login { get; set; }
+
+    [JsonPropertyName("token")]
+    public string Token { get; set; } = string.Empty;
+
+    [JsonPropertyName("empresas")]
+    public List<EmpresasDto>? Empresas { get; set; }
+}

--- a/SistemaVeterinario.Backend/Interfaces/ILoginRepository.cs
+++ b/SistemaVeterinario.Backend/Interfaces/ILoginRepository.cs
@@ -1,9 +1,9 @@
-﻿using SistemaVeterinario.Backend.Entities.Requests;
+using SistemaVeterinario.Backend.Entities.Requests;
+using SistemaVeterinario.Backend.Entities.Responses;
 
-namespace SistemaVeterinario.Backend.Interfaces
+namespace SistemaVeterinario.Backend.Interfaces;
+
+public interface ILoginRepository
 {
-    public interface ILoginRepository
-    {
-        Task<dynamic> IniciarSesion(LoginRequest request);
-    }
+    Task<LoginResponse> IniciarSesion(LoginRequest request);
 }

--- a/SistemaVeterinario.Backend/Interfaces/IMascotaRepository.cs
+++ b/SistemaVeterinario.Backend/Interfaces/IMascotaRepository.cs
@@ -1,11 +1,11 @@
-﻿using SistemaVeterinario.Backend.Entities.Requests;
+using SistemaVeterinario.Backend.Entities.Requests;
 
 namespace SistemaVeterinario.Backend.Interfaces
 {
     public interface IMascotaRepository
     {
         Task<dynamic> GetMascota(string token, string prefijo, string id);
-        Task<dynamic> GetNumeroMascota(string token, string prefijo);
+        Task<string?> GetNumeroMascota(string token, string prefijo);
         Task<dynamic> GetMascotaRutCliente(string token, string prefijo, string rut);
         Task<dynamic> PostMascota(string token, string prefijo, MascotaDtoRequest mascota);
         Task<dynamic> PutMascota(string token, string prefijo, MascotaDtoRequest mascota);

--- a/SistemaVeterinario.Backend/Repositories/LoginRepository.cs
+++ b/SistemaVeterinario.Backend/Repositories/LoginRepository.cs
@@ -1,43 +1,64 @@
-﻿using Newtonsoft.Json.Linq;
-using SistemaVeterinario.Backend.Entities.Requests;
-using SistemaVeterinario.Backend.Interfaces;
-using System.Text;
+using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using SistemaVeterinario.Backend.Entities.Requests;
+using SistemaVeterinario.Backend.Entities.Responses;
+using SistemaVeterinario.Backend.Interfaces;
 
-namespace SistemaVeterinario.Backend.Repositories
+namespace SistemaVeterinario.Backend.Repositories;
+
+public class LoginRepository : ILoginRepository
 {
-    public class LoginRepository : ILoginRepository
+    private static readonly JsonSerializerOptions SerializerOptions = new()
     {
-        private readonly HttpClient httpClient;
-        public LoginRepository(HttpClient _httpClient)
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpClient httpClient;
+    private readonly ILogger<LoginRepository> logger;
+
+    public LoginRepository(HttpClient httpClient, ILogger<LoginRepository> logger)
+    {
+        this.httpClient = httpClient;
+        this.logger = logger;
+    }
+
+    public async Task<LoginResponse> IniciarSesion(LoginRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        using var response = await httpClient.PostAsJsonAsync("api/sales-administrator/login", request);
+        var payload = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
         {
-            httpClient = _httpClient;
+            logger.LogWarning("Error al iniciar sesión. Código {StatusCode}. Respuesta: {Payload}", response.StatusCode, payload);
+            throw new HttpRequestException($"No se pudo iniciar sesión (código {(int)response.StatusCode}). {payload}");
         }
-        public async Task<dynamic> IniciarSesion(LoginRequest request)
+
+        var envelope = JsonSerializer.Deserialize<ApiResponse<List<LoginEnvelopeItem>>>(payload, SerializerOptions);
+        if (envelope is null)
         {
-            try
-            {
-                var json = JsonSerializer.Serialize(request);
-                var content = new StringContent(json, Encoding.UTF8, "application/json");
-                //var response = await httpClient.PostAsync("api/sales-administrator/login", content);
-                var response = await httpClient.PostAsync("api/sales-administrator/login", content);
-                var responseString = await response.Content.ReadAsStringAsync();
-
-                dynamic rsp = JObject.Parse(responseString);
-
-                if (rsp.statusCode == 200)
-                {
-                    return rsp;
-                }
-                return null;
-            }
-            catch (Exception e)
-            {
-                var error = e.Message;
-                throw;
-            }
-
-
+            throw new InvalidOperationException("No se pudo deserializar la respuesta de autenticación.");
         }
+
+        if (!envelope.IsSuccess || envelope.Items is null || envelope.Items.Count == 0)
+        {
+            var message = envelope.Message ?? "La autenticación no devolvió resultados";
+            throw new InvalidOperationException(message);
+        }
+
+        var item = envelope.Items[0];
+        if (item.Login is null || string.IsNullOrWhiteSpace(item.Token))
+        {
+            throw new InvalidOperationException("La respuesta de autenticación está incompleta.");
+        }
+
+        return new LoginResponse
+        {
+            Login = item.Login,
+            Token = item.Token,
+            Empresas = item.Empresas ?? new List<Entities.Dtos.EmpresasDto>()
+        };
     }
 }

--- a/SistemaVeterinario.Backend/Statics/HttpClientNames.cs
+++ b/SistemaVeterinario.Backend/Statics/HttpClientNames.cs
@@ -1,0 +1,6 @@
+namespace SistemaVeterinario.Backend.Statics;
+
+public static class HttpClientNames
+{
+    public const string Api = "API";
+}

--- a/SistemaVeterinario.Components/Components/Login/FormLogin.razor
+++ b/SistemaVeterinario.Components/Components/Login/FormLogin.razor
@@ -1,4 +1,5 @@
-﻿@using SistemaVeterinario.Backend.Interfaces
+@using SistemaVeterinario.Backend.Entities.Responses
+@using SistemaVeterinario.Backend.Interfaces
 @using SistemaVeterinario.Web.Statics
 @inject UserNavgationData userDataService
 @inject ILoginRepository loginRepository
@@ -6,7 +7,8 @@
 @inject IJSRuntime js
 @inject Blazored.LocalStorage.ILocalStorageService localStorage
 @inject MascotaNavigationData mascotaData
-<NavigationLock OnBeforeInternalNavigation="OnBeforeInternalNavigation" />
+@inject ILogger<FormLogin> logger
+
 <EditForm Model="Login">
     <DataAnnotationsValidator/>
     <form class="my-4" action="index.html">
@@ -115,19 +117,18 @@
 
         context.PreventNavigation();
     }
-    private void KeyEvent(KeyboardEventArgs e)
+    private async Task KeyEvent(KeyboardEventArgs e)
     {
-
         if (e.Key == "Enter")
         {
             loading = true;
             StateHasChanged();
-            IniciarSesion();
+            await IniciarSesion();
         }
     }
-    private async void KeyEventRut(KeyboardEventArgs e)
-    {
 
+    private async Task KeyEventRut(KeyboardEventArgs e)
+    {
         if (e.Key == "Enter")
         {
             await pass.FocusAsync();
@@ -147,7 +148,7 @@
             Rut rutFn = new Rut();
             _rut = rutFn.FormatoRut(rutLimpio);
             Login.rut = rutLimpio.PadLeft(10,'0');
-            Console.WriteLine($"rut ----> {Login.rut}");
+            logger.LogDebug("RUT formateado {Rut}", Login.rut);
         }
 
     }
@@ -206,7 +207,7 @@
     {
         await js.InvokeVoidAsync("eval", $"document.getElementById('rut').value = '{palabra}'");
     }
-    private async void ValidaRut()
+    private async Task ValidaRut()
     {
         Rut rutFn = new Rut();
         var res = rutFn.ValidaRut(Login.rut);
@@ -214,60 +215,69 @@
         {
             await js.InvokeAsync<string>("showAlertErrorRut");
         }
-        Console.WriteLine($"RUT CORRECTO?: {res}");
+        logger.LogDebug("Validación de RUT con resultado {Resultado}", res);
     }
-    private async void IniciarSesion()
+    private async Task IniciarSesion()
     {
-        loading = true;
-        var rut = Login.rut.Replace(".", "").Replace("-", "");
-        Login.rut = rut.PadLeft(10, '0');
-        var response = await loginRepository.IniciarSesion(Login);
-        if(response != null)
+        try
         {
-            dynamic prueba = response.items;
-            var admUser = JsonSerializer.Deserialize<AdmUser>(Convert.ToString(prueba[0].login));
+            loading = true;
+            var rut = Login.rut.Replace(".", string.Empty).Replace("-", string.Empty);
+            Login.rut = rut.PadLeft(10, '0');
 
-            List<EmpresasDto> empresas = [];
-            foreach (var item in prueba[0].empresas)
+            LoginResponse loginResult;
+            try
             {
-                empresas.Add(JsonSerializer.Deserialize<EmpresasDto>(Convert.ToString(item)));
+                loginResult = await loginRepository.IniciarSesion(Login);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Error al autenticar al usuario {Rut}", Login.rut);
+                throw;
             }
 
-            string token = prueba[0].token;
-            userDataService.Login = admUser;
-            userDataService.Token = token;
+            if (loginResult.Login is null)
+            {
+                throw new InvalidOperationException("La respuesta de autenticación no contiene datos de usuario.");
+            }
+
+            var empresas = loginResult.Empresas ?? new List<EmpresasDto>();
+
+            userDataService.Login = loginResult.Login;
+            userDataService.Token = loginResult.Token;
             userDataService.Empresas = empresas;
             mascotaData.IdMascota = null;
             mascotaData.RutCliente = null;
+
             await js.InvokeAsync<string>("showAlertSuccessLogin");
-            await localStorage.SetItemAsync("login", new LoginResponse{ Empresas = empresas, Login = admUser, Token = token} );
-            await localStorage.SetItemAsync("mascota", new MascotasDto
-                {
-                    
-                });
-            await localStorage.SetItemAsync("propietario", new Propietario
-                {
-                    
-                });
-            List<MascotasDto> lst = new List<MascotasDto>();
-            await localStorage.SetItemAsync("mascotasPropietario", lst);
+            await localStorage.SetItemAsync("login", new LoginResponse
+            {
+                Empresas = empresas,
+                Login = loginResult.Login,
+                Token = loginResult.Token
+            });
+            await localStorage.SetItemAsync("mascota", new MascotasDto());
+            await localStorage.SetItemAsync("propietario", new Propietario());
+            await localStorage.SetItemAsync("mascotasPropietario", new List<MascotasDto>());
 
             navigationManager.NavigateTo("/home");
-
         }
-        else
+        catch (Exception ex)
         {
-            var rutTemp = Login.rut.Remove(0,1);
+            var rutTemp = Login.rut.Length > 1 ? Login.rut.Remove(0, 1) : Login.rut;
             Rut rutFn = new Rut();
-            loading = false;
-
             rutTemp = rutFn.FormatoRut(rutTemp);
-            StateHasChanged();
             Login.rut = rutTemp;
+            loading = false;
+            StateHasChanged();
+            logger.LogError(ex, "No se pudo iniciar sesión para el usuario {Rut}", Login.rut);
             await js.InvokeAsync<string>("showAlertErrorLogin");
-            
-            //Login.rut = rutFn.FormatoRut(Login.rut.Remove(0));
             await js.InvokeVoidAsync("eval", $"document.getElementById('rut').value = '{Login.rut}'");
+        }
+        finally
+        {
+            loading = false;
+            StateHasChanged();
         }
     }
 }

--- a/SistemaVeterinario.Components/Components/Nueva Mascota/FrmNuevaMascota.razor
+++ b/SistemaVeterinario.Components/Components/Nueva Mascota/FrmNuevaMascota.razor
@@ -14,6 +14,7 @@
 @inject UserNavgationData userLoged
 @inject Blazored.LocalStorage.ILocalStorageService localStorage
 @inject HttpClient Http
+@inject ILogger<FrmNuevaMascota> logger
 
 <style>
     body {
@@ -508,13 +509,19 @@
     protected override async Task OnInitializedAsync()
     {
         MascotaDto.FechaCreacion = DateTime.Now.ToString("yyyy-MM-dd");
-        MascotaDto.IdMascota = await mascota.GetNumeroMascota(userLoged.Token, empresaData.Prefijo);
+        var correlativoMascota = await mascota.GetNumeroMascota(userLoged.Token, empresaData.Prefijo);
+        if (string.IsNullOrWhiteSpace(correlativoMascota))
+        {
+            await js.InvokeVoidAsync("mostrarAlertaError", "No fue posible generar un correlativo para la mascota.");
+            correlativoMascota = string.Empty;
+        }
+        MascotaDto.IdMascota = correlativoMascota;
         MascotaDto.NumeroHospitalizacion = "";
         fechaNacimiento = DateOnly.Parse(DateTime.Now.ToString().Split(" ")[0]);
         MascotaDto.IdFotoPerfil = UrlImagen;
         var id = await mascotasFotosRepository.IdFoto(userLoged.Token, empresaData.Prefijo);
         UrlImagen = $"{Http.BaseAddress}api/imagenes/test/base/base/{ImagenBase}";
-        Console.WriteLine(UrlImagen);
+        logger.LogDebug("URL de imagen de mascota {Url}", UrlImagen);
         int id_convertido = Convert.ToInt32(id) + 1;
         fotos.IdFoto = Convert.ToString(id_convertido).PadLeft(10, '0');
         var sx = await sexo.GetSexos(userLoged.Token, empresaData.Prefijo);
@@ -552,7 +559,7 @@
                 especies = esp;
             }
         }
-        Console.WriteLine("url: " + Http.BaseAddress);
+        logger.LogDebug("Base address API {BaseAddress}", Http.BaseAddress);
         // var raz = await raza.GetRazas(userLoged.Token,empresaData.Prefijo);
         // if (raz != null)
         // {
@@ -621,7 +628,7 @@
                     fotos.IdMascota = MascotaDto.IdMascota;
                     fotos.IdCliente = MascotaDto.RutCliente;
                     UrlImagen = $"{Http.BaseAddress}api/imagenes/test/{MascotaDto.RutCliente}/{MascotaDto.IdMascota}/{ImagenBase}";
-                    Console.WriteLine(UrlImagen);
+                    logger.LogDebug("URL de imagen de mascota {Url}", UrlImagen);
                     StateHasChanged();
                 }
                 else

--- a/SistemaVeterinario.Multiplataforma/MauiProgram.cs
+++ b/SistemaVeterinario.Multiplataforma/MauiProgram.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.Extensions.Logging;
+using System.Net;
+using Microsoft.Extensions.Logging;
 using SistemaVeterinario.Backend.Interfaces;
 using SistemaVeterinario.Backend.NavigationData;
 using SistemaVeterinario.Backend.Repositories;
+using SistemaVeterinario.Backend.Statics;
 
 namespace SistemaVeterinario.Multiplataforma
 {
@@ -16,14 +18,35 @@ namespace SistemaVeterinario.Multiplataforma
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 });
+
+            builder.Configuration
+                   .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                   .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true);
+
+            var apiBaseUrl = builder.Configuration["Api:BaseUrl"];
+
             builder.Services.AddSingleton<UserNavgationData>();
-            builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("http://45.236.164.152:82/") });
+            builder.Services.AddHttpClient(HttpClientNames.Api, client =>
+            {
+                if (!string.IsNullOrWhiteSpace(apiBaseUrl) && Uri.TryCreate(apiBaseUrl, UriKind.Absolute, out var baseUri))
+                {
+                    client.BaseAddress = baseUri;
+                }
+                else
+                {
+                    client.BaseAddress = new Uri("https://localhost:7218/");
+                }
+
+                client.DefaultRequestVersion = HttpVersion.Version20;
+                client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+            });
+            builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient(HttpClientNames.Api));
             builder.Services.AddScoped<ILoginRepository, LoginRepository>();
             builder.Services.AddMauiBlazorWebView();
 
 #if DEBUG
-    		builder.Services.AddBlazorWebViewDeveloperTools();
-    		builder.Logging.AddDebug();
+                builder.Services.AddBlazorWebViewDeveloperTools();
+                builder.Logging.AddDebug();
 #endif
 
             return builder.Build();

--- a/SistemaVeterinario.Multiplataforma/SistemaVeterinario.Multiplataforma.csproj
+++ b/SistemaVeterinario.Multiplataforma/SistemaVeterinario.Multiplataforma.csproj
@@ -73,7 +73,17 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\SistemaVeterinario.Backend\SistemaVeterinario.Backend.csproj" />
       <ProjectReference Include="..\SistemaVeterinario.Components\SistemaVeterinario.Components.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Content Include="appsettings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="appsettings.Development.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
 
     <ItemGroup>

--- a/SistemaVeterinario.Multiplataforma/appsettings.Development.json
+++ b/SistemaVeterinario.Multiplataforma/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "Api": {
+    "BaseUrl": "https://localhost:7218/"
+  }
+}

--- a/SistemaVeterinario.Multiplataforma/appsettings.json
+++ b/SistemaVeterinario.Multiplataforma/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "Api": {
+    "BaseUrl": "https://localhost:7218/"
+  }
+}

--- a/SistemaVeterinario.Web/Program.cs
+++ b/SistemaVeterinario.Web/Program.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -5,6 +6,7 @@ using Radzen;
 using SistemaVeterinario.Backend.Interfaces;
 using SistemaVeterinario.Backend.NavigationData;
 using SistemaVeterinario.Backend.Repositories;
+using SistemaVeterinario.Backend.Statics;
 using SistemaVeterinario.Web;
 using SistemaVeterinario.Web.Services;
 
@@ -17,9 +19,22 @@ builder.Services.AddScoped<DialogService>();
 builder.Services.AddSingleton<UserNavgationData>();
 builder.Services.AddSingleton<MascotaNavigationData>();
 builder.Services.AddSingleton<EmpresaSeleccionadaNavigationData>();
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("http://45.236.164.152:82/") }); //VPN
-//builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("http://192.168.1.2:88/") }); //oficina
-//builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri("http://10.32.64.8:88/") }); // CASA
+var apiBaseUrl = builder.Configuration["Api:BaseUrl"];
+builder.Services.AddHttpClient(HttpClientNames.Api, client =>
+{
+    if (!string.IsNullOrWhiteSpace(apiBaseUrl) && Uri.TryCreate(apiBaseUrl, UriKind.Absolute, out var baseUri))
+    {
+        client.BaseAddress = baseUri;
+    }
+    else
+    {
+        client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress);
+    }
+
+    client.DefaultRequestVersion = HttpVersion.Version20;
+    client.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+});
+builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>().CreateClient(HttpClientNames.Api));
 builder.Services.AddScoped<ILoginRepository, LoginRepository>();
 builder.Services.AddScoped<ArchivosService>();
 builder.Services.AddScoped<IAyudaRepository, AyudaRepository>();

--- a/SistemaVeterinario.Web/Services/Contracts/CreateFileResourceRequest.cs
+++ b/SistemaVeterinario.Web/Services/Contracts/CreateFileResourceRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SistemaVeterinario.Web.Services.Contracts;
+
+public sealed class CreateFileResourceRequest
+{
+    [MaxLength(64)]
+    public string? MascotaId { get; set; }
+}

--- a/SistemaVeterinario.Web/Services/Contracts/FileResourceResponse.cs
+++ b/SistemaVeterinario.Web/Services/Contracts/FileResourceResponse.cs
@@ -1,0 +1,7 @@
+namespace SistemaVeterinario.Web.Services.Contracts;
+
+public sealed class FileResourceResponse
+{
+    public required string ResourceId { get; init; }
+    public required string RelativePath { get; init; }
+}

--- a/SistemaVeterinario.Web/SistemaVeterinario.Web.csproj
+++ b/SistemaVeterinario.Web/SistemaVeterinario.Web.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\SistemaVeterinario.Backend\SistemaVeterinario.Backend.csproj" />
     <ProjectReference Include="..\SistemaVeterinario.Components\SistemaVeterinario.Components.csproj" />
   </ItemGroup>
 

--- a/SistemaVeterinario.Web/wwwroot/appsettings.Development.json
+++ b/SistemaVeterinario.Web/wwwroot/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+  "Api": {
+    "BaseUrl": "https://localhost:7218/"
+  }
+}

--- a/SistemaVeterinario.Web/wwwroot/appsettings.json
+++ b/SistemaVeterinario.Web/wwwroot/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "Api": {
+    "BaseUrl": "https://localhost:7218/"
+  }
+}

--- a/SistemaVeterinario.sln
+++ b/SistemaVeterinario.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SistemaVeterinario.Web", "S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SistemaVeterinario.Backend", "SistemaVeterinario.Backend\SistemaVeterinario.Backend.csproj", "{952FB8A2-C050-43BA-8AE3-0CBD2B6D9F46}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SistemaVeterinario.Api", "SistemaVeterinario.Api\SistemaVeterinario.Api.csproj", "{734DF85A-6E1B-4853-BC4D-8BD534B9BA55}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,9 +35,13 @@ Global
 		{4FFFED7B-1337-4F53-B4EF-0033DC0239E1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{952FB8A2-C050-43BA-8AE3-0CBD2B6D9F46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{952FB8A2-C050-43BA-8AE3-0CBD2B6D9F46}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{952FB8A2-C050-43BA-8AE3-0CBD2B6D9F46}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{952FB8A2-C050-43BA-8AE3-0CBD2B6D9F46}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {952FB8A2-C050-43BA-8AE3-0CBD2B6D9F46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {952FB8A2-C050-43BA-8AE3-0CBD2B6D9F46}.Release|Any CPU.Build.0 = Release|Any CPU
+                {734DF85A-6E1B-4853-BC4D-8BD534B9BA55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {734DF85A-6E1B-4853-BC4D-8BD534B9BA55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {734DF85A-6E1B-4853-BC4D-8BD534B9BA55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {734DF85A-6E1B-4853-BC4D-8BD534B9BA55}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Resumen
- Externalicé la creación de carpetas a un nuevo proyecto ASP.NET Core `SistemaVeterinario.Api` con endpoint protegido para registrar recursos de archivos.
- Ajusté la configuración de HttpClient en WebAssembly y MAUI para usar `IHttpClientFactory`, URLs configurables via appsettings y nombres compartidos.
- Reemplacé el uso de `dynamic` en el inicio de sesión por DTOs tipados y mejor manejo de errores; robustecí la obtención de correlativos de mascotas y eliminé `Console.WriteLine` en los flujos tocados.

## Motivación
Endurecer el manejo de archivos, autenticación y consumo HTTP eliminando IO local en WASM, mejorando la observabilidad y evitando respuestas dinámicas frágiles.

## Cambios
- Nuevo proyecto API con controlador `FilesController`, servicio `LocalFileStorageService` y opciones configurables.
- Configuración de clientes HTTP nombrados (`API`) en WebAssembly y MAUI, más appsettings por entorno.
- Repositorios `LoginRepository` y `MascotaRepository` usan DTOs fuertes, logging e inyección de `ILogger`.
- Componentes de login y nueva mascota ahora usan `async Task`, logging y feedback frente a errores de correlativo.

## Riesgos
- El nuevo proyecto API requiere despliegue y configuración de JWT (placeholders en appsettings).
- Cambios en contratos de repositorios pueden requerir ajustes adicionales en componentes no tocados que aún usan `dynamic` (TODO futuros).

## Cómo probar
1. Levantar la nueva API (`SistemaVeterinario.Api`) y configurar `Api:BaseUrl` en los appsettings.
2. Ejecutar la app WASM; validar login, creación de mascotas y que el servicio de archivos responda con rutas válidas.
3. Probar la app MAUI asegurando que consume la URL configurada.

## Checklist
- [ ] `dotnet build` backend (no disponible en entorno, requiere validación local)
- [ ] `dotnet build` frontend (no disponible en entorno, requiere validación local)
- [ ] `dotnet format` / análisis estático (pendiente por falta de SDK)
- [ ] Smoke test manual: Login, flujo mascota y correlativo (validar una vez desplegado)


------
https://chatgpt.com/codex/tasks/task_e_68e410ba74308325a925db709a8771bc